### PR TITLE
Add "version" key

### DIFF
--- a/custom_components/myhome/manifest.json
+++ b/custom_components/myhome/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "myhome",
   "name": "MyHOME",
+  "version": "0.7.3",
   "config_flow": true,
   "documentation": "",
   "requirements": ["OWNd==0.7.22"],


### PR DESCRIPTION
Home Assistant gives an error if a custom integration doesn't include the "version" key in the manifest.json