### PR TITLE
Fix format_mac when registering a device

### DIFF
--- a/custom_components/myhome/config_flow.py
+++ b/custom_components/myhome/config_flow.py
@@ -155,7 +155,7 @@ class MyhomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
             try:
                 user_input["serialNumber"] = device_registry.format_mac(
-                    MACAddress(user_input["serialNumber"])
+                    f'{MACAddress(user_input["serialNumber"])}'
                 )
             except ValueError:
                 errors["serialNumber"] = "invalid_mac"


### PR DESCRIPTION
```
  File "/usr/src/homeassistant/homeassistant/helpers/device_registry.py", line 134, in format_mac
    if len(to_test) == 17 and to_test.count(":") == 5:
TypeError: object of type 'MACAddress' has no len()
```

The `format_mac` function expects an argument of type str, but receives `MacAddress` class. Apperently, both this MyHome integration and HomeAssistant do a check on the MacAddres/serial number. Did not want to change this.