### PR TITLE
fixed deprecation warning in HA 2022.6

### DIFF
--- a/custom_components/myhome/config_flow.py
+++ b/custom_components/myhome/config_flow.py
@@ -1,41 +1,40 @@
 """Config flow to configure MyHome."""
 import asyncio
-from typing import Dict, Optional
 import ipaddress
 import re
+from typing import Dict, Optional
+
 import async_timeout
 import voluptuous as vol
-
 from homeassistant.config_entries import (
+    CONN_CLASS_LOCAL_PUSH,
     ConfigEntry,
     ConfigFlow,
     OptionsFlow,
-    CONN_CLASS_LOCAL_PUSH,
+)
+from homeassistant.const import (
+    CONF_FRIENDLY_NAME,
+    CONF_HOST,
+    CONF_ID,
+    CONF_MAC,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
 )
 from homeassistant.core import callback
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PORT,
-    CONF_PASSWORD,
-    CONF_NAME,
-    CONF_MAC,
-    CONF_ID,
-    CONF_FRIENDLY_NAME,
-)
-from homeassistant.helpers import device_registry
-
-from OWNd.connection import OWNSession, OWNGateway
+from homeassistant.helpers import device_registry as dr
+from OWNd.connection import OWNGateway, OWNSession
 from OWNd.discovery import find_gateways
 
 from .const import (
     CONF_ADDRESS,
-    CONF_OWN_PASSWORD,
-    CONF_FIRMWARE,
-    CONF_SSDP_LOCATION,
-    CONF_SSDP_ST,
     CONF_DEVICE_TYPE,
+    CONF_FIRMWARE,
     CONF_MANUFACTURER,
     CONF_MANUFACTURER_URL,
+    CONF_OWN_PASSWORD,
+    CONF_SSDP_LOCATION,
+    CONF_SSDP_ST,
     CONF_UDN,
     CONF_WORKER_COUNT,
     DOMAIN,
@@ -93,7 +92,7 @@ class MyhomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 self.discovered_gateways[user_input["serial"]]
             )
             await self.async_set_unique_id(
-                device_registry.format_mac(self.gateway_handler.serial),
+                dr.format_mac(self.gateway_handler.serial),
                 raise_on_progress=False,
             )
             # We pass user input to link so it will attempt to link right away
@@ -154,7 +153,7 @@ class MyhomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors["address"] = "invalid_ip"
 
             try:
-                user_input["serialNumber"] = device_registry.format_mac(
+                user_input["serialNumber"] = dr.format_mac(
                     MACAddress(user_input["serialNumber"])
                 )
             except ValueError:
@@ -274,7 +273,7 @@ class MyhomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if test_result["Success"]:
             _new_entry_data = {
-                CONF_ID: device_registry.format_mac(gateway.serial),
+                CONF_ID: dr.format_mac(gateway.serial),
                 CONF_HOST: gateway.address,
                 CONF_PORT: gateway.port,
                 CONF_PASSWORD: gateway.password,
@@ -286,7 +285,7 @@ class MyhomeFlowHandler(ConfigFlow, domain=DOMAIN):
                 CONF_MANUFACTURER_URL: gateway.manufacturer_url,
                 CONF_NAME: gateway.model_name,
                 CONF_FIRMWARE: gateway.model_number,
-                CONF_MAC: device_registry.format_mac(gateway.serial),
+                CONF_MAC: dr.format_mac(gateway.serial),
                 CONF_UDN: gateway.udn,
             }
             _new_entry_options = {
@@ -405,7 +404,7 @@ class MyhomeFlowHandler(ConfigFlow, domain=DOMAIN):
         _discovery_info["port"] = 20000
 
         gateway = await OWNGateway.build_from_discovery_info(_discovery_info)
-        await self.async_set_unique_id(device_registry.format_mac(gateway.unique_id))
+        await self.async_set_unique_id(dr.format_mac(gateway.unique_id))
         LOGGER.info("Found gateway: %s", gateway.address)
         updatable = {
             CONF_HOST: gateway.address,

--- a/custom_components/myhome/sensor.py
+++ b/custom_components/myhome/sensor.py
@@ -1,59 +1,56 @@
 """Support for MyHome sensors (power/energy, temperature, illuminance)."""
 from datetime import timedelta
-import voluptuous as vol
 
+import voluptuous as vol
+from homeassistant.components.sensor import DOMAIN as PLATFORM
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA,
-    DOMAIN as PLATFORM,
-    SensorStateClass,
     SensorDeviceClass,
     SensorEntity,
+    SensorStateClass,
 )
 from homeassistant.const import (
-    CONF_NAME,
     CONF_DEVICES,
     CONF_ENTITIES,
-    POWER_WATT,
+    CONF_NAME,
     ENERGY_WATT_HOUR,
-    TEMP_CELSIUS,
     LIGHT_LUX,
+    POWER_WATT,
+    TEMP_CELSIUS,
 )
-from homeassistant.helpers import (
-    config_validation as cv,
-    entity_platform,
-    entity_registry,
-)
-
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_platform
+from homeassistant.helpers import entity_registry as er
 from OWNd.message import (
     MESSAGE_TYPE_ACTIVE_POWER,
-    MESSAGE_TYPE_ENERGY_TOTALIZER,
     MESSAGE_TYPE_CURRENT_DAY_CONSUMPTION,
     MESSAGE_TYPE_CURRENT_MONTH_CONSUMPTION,
+    MESSAGE_TYPE_ENERGY_TOTALIZER,
+    MESSAGE_TYPE_ILLUMINANCE,
     MESSAGE_TYPE_MAIN_TEMPERATURE,
     MESSAGE_TYPE_SECONDARY_TEMPERATURE,
-    MESSAGE_TYPE_ILLUMINANCE,
-    OWNEnergyEvent,
     OWNEnergyCommand,
-    OWNHeatingEvent,
+    OWNEnergyEvent,
     OWNHeatingCommand,
+    OWNHeatingEvent,
     OWNLightingCommand,
     OWNLightingEvent,
 )
 
 from .const import (
     CONF,
-    CONF_GATEWAY,
-    CONF_WHO,
-    CONF_WHERE,
-    CONF_MANUFACTURER,
-    CONF_DEVICE_MODEL,
     CONF_DEVICE_CLASS,
+    CONF_DEVICE_MODEL,
+    CONF_GATEWAY,
     CONF_INVERTED,
+    CONF_MANUFACTURER,
+    CONF_WHERE,
+    CONF_WHO,
     DOMAIN,
     LOGGER,
 )
-from .myhome_device import MyHOMEEntity
 from .gateway import MyHOMEGatewayHandler
+from .myhome_device import MyHOMEEntity
 
 SCAN_INTERVAL = timedelta(seconds=60)
 
@@ -180,7 +177,7 @@ async def async_setup_entry(
             if _configured_sensors[_sensor][CONF_DEVICE_CLASS] == SensorDeviceClass.POWER:
                 _power_devices_configured = True
 
-                ent_reg = entity_registry.async_get(hass)
+                ent_reg = er.async_get(hass)
                 existing_entity_id = ent_reg.async_get_entity_id(
                     "sensor", DOMAIN, _sensor
                 )

--- a/hacs.json
+++ b/hacs.json
@@ -4,7 +4,5 @@
   "filename": "myhome.zip",
   "render_readme": true,
   "country": ["EN", "FR", "NL", "IT"],
-  "domains": ["light", "switch", "cover", "climate", "binary_sensor", "sensor"],
-  "homeassistant": "2021.9",
-  "iot_class": ["Local Push"]
+  "homeassistant": "2022.6.0"
 }


### PR DESCRIPTION
- Cleanup deprecated async_get_registry in init file.
- Cleanup deprecated keys in hacs.json file.
- Code black formatting, isort.