### PR TITLE
Update gateway.py, added a test that dimmer exists in configuration b…

### DIFF
--- a/custom_components/myhome/gateway.py
+++ b/custom_components/myhome/gateway.py
@@ -257,7 +257,7 @@ class MyHOMEGatewayHandler:
                             )
                     if not is_event:
                         if isinstance(message, OWNLightingEvent) and message.brightness_preset:
-                            if isinstance(
+                            if message.entity in self.hass.data[DOMAIN][self.mac][CONF_PLATFORMS][LIGHT] and isinstance(
                                 self.hass.data[DOMAIN][self.mac][CONF_PLATFORMS][LIGHT][message.entity][CONF_ENTITIES][LIGHT],
                                 MyHOMEEntity,
                             ):


### PR DESCRIPTION
…efore running code

I was testing my installation and encountered a case that crashed the myhome integration.
I a dimmer is not defined in the configuration, and you press a button triggering a dimmer light, it made the integration crashed.

I added a test to check that the dimmer light really exists before replicating the received order from the gateway.